### PR TITLE
feat: adding possibility to override default selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ generating `.gitignore` files offline, and directly from within neovim.
 
 ## Installation & Dependencies
 **`gitignore.nvim` optionally depends on
-[telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) because of [multiple selection](#possibility-of-multiselect).
-If you want to have multiselect, please [install](https://github.com/nvim-telescope/telescope.nvim#installation) that plugin first!**
+[telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) to provide
+[multi-selection](#selecting-multiple-items). Without [installing
+telescope](https://github.com/nvim-telescope/telescope.nvim#installation) you
+will not be able to select multiple technologies.
 
 After installing `telescope.nvim`, you can install `gitignore.nvim` like this:
 
@@ -38,7 +40,7 @@ Using [packer.nvim](https://github.com/wbthomason/packer.nvim):
 use({
      "wintermute-cell/gitignore.nvim",
      requires = {
-        "nvim-telescope/telescope.nvim" -- optional: for multiselect
+        "nvim-telescope/telescope.nvim" -- optional: for multi-select
      }
 })
 ```
@@ -74,11 +76,22 @@ vim.keymap.set("n", "<leader>gi",
 )
 ```
 
-### Possibility of multiselect
-
-By default, setting dont provide multiselect because of `vim.ui.select()` can select only one item. Therefore if you want to use multiselect, you must add plugin telescope.nvim as dependency or override method `generate` ([see section below](#custom-pickers-window)).
-
 ### Selecting multiple items
+Without telescope, `gitignore.nvim` does not allow you to select multiple
+technologies for your `.gitignore`, since the fallback picker, `vim.ui.select()`,
+can only select one item.
+Therefore, if you want to be able to select multiple technologies, you must
+either [install
+telescope.nvim](https://github.com/nvim-telescope/telescope.nvim#installation)
+(you may find an example using `packer.nvim` in the
+[Installation](#installation--dependencies) section), or override the provided
+`generate` method with your own implementation ([see section
+below](#custom-picker)).
+
+`gitignore.nvim` will detect if `telescope.nvim` is installed and use it
+automatically, there is no further configuration required.
+
+### Selecting multiple items with telescope.nvim installed
 `gitignore.nvim` makes use of `telescope.nvim`'s multi-selection keybinds. 
 This means that by default, you can (de-)select multiple keywords with `<Tab>`,
 and confirm your selection with `<CR>` (Enter).
@@ -96,22 +109,24 @@ instead of appending to it, you can set:
 vim.g.gitignore_nvim_overwrite = true
 ```
 If this variable is set to `false`, or not set at all, `:Gitignore` will take
-into account an existing gitignore.
+into account an existing `.gitignore`.
 
-### Custom pickers window
+### Custom Picker
 
-If you want to create your custom pickers window, follow the contract below:
-1. plugin provide list of templateNames and two methods `generate` and `createGititnoreBuffer`;
-2. method `generate` must get list of opts like path and list can be empty but not null;
-3. pass to `createGitignoreBuffer` only list of selected templateNames;
+Instead of using `telescope.nvim` or the native `vim.ui.select()`, you may
+implement your own solution according to the following contract:
+1. `gitignore.nvim` provides list of templateNames and two methods `generate` and `createGititnoreBuffer`.
+2. As its first parameter, the `generate` method will receive an `opts` table, containing the target path for the `.gitignore` in `opts.args`.
+3. One must pass on `opts.args`, and a list of selected templateNames to `createGitignoreBuffer`.
 
-Here's a implementation with fzf-lua:
+Here's an example implementation using fzf-lua:
 ```lua
 local gitignore = require("gitignore")
 local fzf = require("fzf-lua")
 
 gitignore.generate = function(opts)
     local picker_opts = {
+        -- the content of opts.args may also be displayed here for example.
         prompt = "Select templates for gitignore file> ",
         winopts = {
             width = 0.4,
@@ -119,6 +134,8 @@ gitignore.generate = function(opts)
         },
         actions = {
             default = function(selected, _)
+                -- as stated in point (3) of the contract above, opts.args and
+                -- a list of selected templateNames are passed.
                 gitignore.createGitignoreBuffer(opts.args, selected)
             end,
         },
@@ -132,7 +149,9 @@ gitignore.generate = function(opts)
 end
 ```
 > __Note__
-> It will not override user command `:Gitignore`. If you want to change it, write the line:
+> Note that the above will not overwrite the `:Gitignore` command.
+> To do that, recreate the command after defining your generate function as
+> follows:
 ```lua
 vim.api.nvim_create_user_command("Gitignore", gitignore.generate, { nargs = "?", complete = "file" })
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ generating `.gitignore` files offline, and directly from within neovim.
 [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) to provide
 [multi-selection](#selecting-multiple-items). Without [installing
 telescope](https://github.com/nvim-telescope/telescope.nvim#installation) you
-will not be able to select multiple technologies.
+will not be able to select multiple technologies.**
 
 After installing `telescope.nvim`, you can install `gitignore.nvim` like this:
 

--- a/lua/gitignore/init.lua
+++ b/lua/gitignore/init.lua
@@ -66,6 +66,10 @@ local function createGitignore(selectionList, order)
     table.insert(ignoreLines, '')
     for _, prefix in ipairs(s) do
         local p = getTmplKeysForPrefix(prefix)
+        if #p == 0 then
+            vim.schedule(function () print('Error while creating .gitignore, unknown selection: ' .. prefix) end)
+            return nil
+        end
         for _, templateKey in ipairs(p) do
             local fileLines = vim.split(templates_data[templateKey], '\n')
             for _, line in ipairs(fileLines) do
@@ -91,6 +95,9 @@ function M.createGitignoreBuffer(chosen_path, selectionList, prompt_bufnr)
         return
     end
     local ignoreLines = createGitignore(selectionList, order_data)
+    if ignoreLines == nil then
+        return
+    end
     local gitignoreFile = chosen_path
     -- Check if chosen_path is empty, if so set gitignoreFile as ".gitignore".
     if not gitignoreFile or gitignoreFile == "" then

--- a/lua/gitignore/init.lua
+++ b/lua/gitignore/init.lua
@@ -85,14 +85,12 @@ end
 ---@param selectionList table list of selected templateNames
 ---@param prompt_bufnr? number bufnr for closing telescope plugin if exists
 function M.createGitignoreBuffer(chosen_path, selectionList, prompt_bufnr)
-    local ignoreLines = createGitignore(selectionList, order_data)
-    if #ignoreLines < 1 then
-        return
-    else
+    if #selectionList < 1 then
         removeBufIfHasTelescope(prompt_bufnr)
         vim.schedule(function () print('Nothing selected, creation of .gitignore cancelled!') end)
+        return
     end
-
+    local ignoreLines = createGitignore(selectionList, order_data)
     local gitignoreFile = chosen_path
     -- Check if chosen_path is empty, if so set gitignoreFile as ".gitignore".
     if not gitignoreFile or gitignoreFile == "" then

--- a/lua/gitignore/init.lua
+++ b/lua/gitignore/init.lua
@@ -1,10 +1,3 @@
-local has_telescope, _ = pcall(require, "telescope")
-if not has_telescope then
-    error(
-        "This plugin requires telescope.nvim (https://github.com/nvim-telescope/telescope.nvim)"
-    )
-end
-
 local M = {}
 
 -- GENERIC HELPER FUNCTIONS
@@ -15,15 +8,7 @@ local function filter(tbl, f) local t = {} local i = 1 for _, v in ipairs(tbl) d
 local function endsWith(str, ending) return string.sub(str, -#ending) == ending end
 local function collapseEmptyLines(tbl) local t = {} local lastValWasEmptyString = false for _, value in ipairs(tbl) do if (not lastValWasEmptyString) or value ~= '' then table.insert(t, value) end if value == '' then lastValWasEmptyString = true else lastValWasEmptyString = false end end return t end
 local function getKeysInTable(tbl) local keys = {} for k, _ in pairs(tbl) do keys[#keys+1] = k end return keys end
-
-
--- TELESCOPE STUFF
-local themes = require("telescope.themes")
-local actions = require("telescope.actions")
-local state = require("telescope.actions.state")
-local pickers = require("telescope.pickers")
-local finders = require("telescope.finders")
-local conf = require("telescope.config").values
+local function removeBufIfHasTelescope(prompt_bufnr) if prompt_bufnr and pcall(require, "telescope") then require("telescope.actions").close(prompt_bufnr) end end
 
 -- DEFINITIONS
 local DEFAULT_TITLE = 'Creating .gitignore: Make your choice(s)'
@@ -34,7 +19,7 @@ local order_data = require("gitignore.order")
 
 -- THE REST OF THE PLUGIN
 local templateKeys = getKeysInTable(templates_data)
-local prefixes = removeDuplicates(map(
+M.templateNames = removeDuplicates(map(
     templateKeys,
     function (path) return path:sub(1, path:find('%.')-1) end
 ))
@@ -62,7 +47,6 @@ local function getTmplKeysForPrefix(prefix)
     end
     return matches
 end
-
 
 local function createGitignore(selectionList, order)
     local s = removeDuplicates(selectionList)
@@ -96,7 +80,19 @@ local function createGitignore(selectionList, order)
     return x
 end
 
-local function createGitignoreBuffer(chosen_path, ignoreLines, prompt_bufnr)
+--- Creates the gitignore to new buffer or new file if path is provided.
+---@param chosen_path? string path to .gitignore
+---@param selectionList table list of selected templateNames
+---@param prompt_bufnr? number bufnr for closing telescope plugin if exists
+function M.createGitignoreBuffer(chosen_path, selectionList, prompt_bufnr)
+    local ignoreLines = createGitignore(selectionList, order_data)
+    if #ignoreLines < 1 then
+        return
+    else
+        removeBufIfHasTelescope(prompt_bufnr)
+        vim.schedule(function () print('Nothing selected, creation of .gitignore cancelled!') end)
+    end
+
     local gitignoreFile = chosen_path
     -- Check if chosen_path is empty, if so set gitignoreFile as ".gitignore".
     if not gitignoreFile or gitignoreFile == "" then
@@ -130,19 +126,25 @@ local function createGitignoreBuffer(chosen_path, ignoreLines, prompt_bufnr)
     if not ok then
         vim.schedule(function () print('Buffer with name \'.gitignore\' already exists, didn\'t name buffer!') end)
     end
-    actions.close(prompt_bufnr)
+    removeBufIfHasTelescope(prompt_bufnr)
     vim.api.nvim_win_set_buf(0, new_buf)
 end
 
+local function call_telescope_win(opts, sorter_opts)
+    -- TELESCOPE STUFF
+    local themes = require("telescope.themes")
+    local actions = require("telescope.actions")
+    local state = require("telescope.actions.state")
+    local pickers = require("telescope.pickers")
+    local finders = require("telescope.finders")
+    local conf = require("telescope.config").values
 
-
-function M.generate(opts, sorter_opts)
     sorter_opts = sorter_opts or {}
     local defaults = {
         prompt_title = DEFAULT_TITLE,
         previewer = false,
         finder = finders.new_table({
-            results = prefixes,
+            results = M.templateNames,
         }),
         sorter = conf.generic_sorter(sorter_opts),
         attach_mappings = function(prompt_bufnr)
@@ -163,13 +165,7 @@ function M.generate(opts, sorter_opts)
                 if #multiSelection <= 0 then
                     multiSelection = {state.get_selected_entry()[1]}
                 end
-                local ignoreLines = createGitignore(multiSelection, order_data)
-                if #ignoreLines > 0 then
-                    createGitignoreBuffer(opts.args, ignoreLines, prompt_bufnr)
-                else
-                    actions.close(prompt_bufnr)
-                    vim.schedule(function () print('Nothing selected, creation of .gitignore cancelled!') end)
-                end
+                M.createGitignoreBuffer(opts.args, multiSelection, prompt_bufnr)
             end)
 
             actions.toggle_selection:enhance({
@@ -205,6 +201,23 @@ function M.generate(opts, sorter_opts)
         end,
     }
     return pickers.new(themes.get_dropdown(), defaults):find()
+end
+
+--- Create a window to pick gitignores
+---@param opts table options that passed in cmd
+---@param sorter_opts? table opts for telescope sorters if exists
+function M.generate(opts, sorter_opts)
+	local has_telescope, _ = pcall(require, "telescope")
+	if has_telescope then
+		return call_telescope_win(opts, sorter_opts)
+	end
+
+	local winopts = {
+		prompt = DEFAULT_TITLE,
+	}
+	vim.ui.select(M.templateNames, winopts, function(selected)
+		M.createGitignoreBuffer(opts.args, { selected })
+	end)
 end
 
 vim.api.nvim_create_user_command('Gitignore', M.generate, { nargs = '?', complete = 'file' })


### PR DESCRIPTION
This is PR solve #1 issue.

Here are things I did:
1. renamed variable `prefixes` to `templateName` (this name is better for understanding IMHO);
2. removed the need to install the telescope.nvim plugin to reach a wide audience and set vim.ui.select as default;
3. moved the code part of generating `ignoreLines` to the `createGititnoreBuffer` method;
4. added the possibility to override the `generate` method with the following contract;

Also users who use telescope can use it continuously, because the plugin telescope.nvim is not needed, but it enables multiple selection.

Contract of the overriding `generate` method:
1. plugin provides list of templateNames and two methods `generate` and `createGititnoreBuffer`;
2. method `generate` must get list of opts like path and list can be empty but not null;
3. pass only list of selected template names to `createGitignoreBuffer';

An example of overriding can be found in README.md.
UPD: I'm sorry if you're confused about block functions instead of ternary operators because of my code formatter.
